### PR TITLE
Update API Endpoints to use new api.track.toggl.com domain

### DIFF
--- a/TogglApi.Client.Tests/General/WorkspaceClientTests.cs
+++ b/TogglApi.Client.Tests/General/WorkspaceClientTests.cs
@@ -21,7 +21,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("A", workspaces[0].Name);
             Assert.Equal("USD", workspaces[0].DefaultCurrency);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces", handlerMock);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("A", workspace.Name);
             Assert.Equal("USD", workspace.DefaultCurrency);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1", handlerMock);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal(1, groups[0].WorkspaceId);
             Assert.Equal("A Team", groups[0].Name);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/groups", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/groups", handlerMock);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal(1, projects[0].WorkspaceId);
             Assert.Equal("A", projects[0].Name);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/projects", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/projects", handlerMock);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("a@a.com", users[0].Email);
             Assert.Equal("A A", users[0].Fullname);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/users", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/users", handlerMock);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("A", clients[0].Name);
             Assert.Equal(new DateTime(2019,2,27,16,31,22), clients[0].At);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/users", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/users", handlerMock);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("A", tags[0].Name);
             Assert.Equal(new DateTime(2018,6,28,12,42,37), tags[0].At);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/tags", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/tags", handlerMock);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace TogglApi.Client.Tests.General
             Assert.Equal("A", tasks[0].Name);
             Assert.Equal(new DateTime(2017,5,9,8,8,51), tasks[0].At);
  
-            MockedClientHelper.ValidateUrlRequest("https://www.toggl.com/api/v8/workspaces/1/tasks", handlerMock);
+            MockedClientHelper.ValidateUrlRequest("https://api.track.toggl.com/api/v8/workspaces/1/tasks", handlerMock);
         }
     }
 }

--- a/TogglApi.Client/Configuration.cs
+++ b/TogglApi.Client/Configuration.cs
@@ -20,9 +20,9 @@
         /// </summary>
         public string WebBaseUrl { get; }
 
-        public Configuration(string apiBaseUrl = "https://www.toggl.com/api/v8",
-            string reportsApiBaseUrl = "https://toggl.com/reports/api/v2",
-            string webBaseUrl = "https://www.toggl.com/app")
+        public Configuration(string apiBaseUrl = "https://api.track.toggl.com/api/v8",
+            string reportsApiBaseUrl = "https://api.track.toggl.com/reports/api/v2",
+            string webBaseUrl = "https://api.track.toggl.com/app")
         {
             ApiBaseUrl = apiBaseUrl;
             ReportsApiBaseUrl = reportsApiBaseUrl;

--- a/TogglApi.Client/General/Models/Request/WorkspaceGroupRequestConfig.cs
+++ b/TogglApi.Client/General/Models/Request/WorkspaceGroupRequestConfig.cs
@@ -2,7 +2,7 @@
 {
     public class WorkspaceGroupRequestConfig : BaseRequestConfig
     {
-        public WorkspaceGroupRequestConfig(long workspaceId) : base($"https://www.toggl.com/api/v8/workspaces/{workspaceId}/groups")
+        public WorkspaceGroupRequestConfig(long workspaceId) : base($"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/groups")
         {
         }
     }

--- a/TogglApi.Client/General/Models/Request/WorkspaceProjectRequestConfig.cs
+++ b/TogglApi.Client/General/Models/Request/WorkspaceProjectRequestConfig.cs
@@ -3,7 +3,7 @@
     public class WorkspaceProjectRequestConfig : BaseRequestConfig
     {
         public WorkspaceProjectRequestConfig(long workspaceId, bool? active=null, bool actualHours=false, bool onlyTemplates=false) 
-            : base($"https://www.toggl.com/api/v8/workspaces/{workspaceId}/projects")
+            : base($"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/projects")
         {
             UrlParameters.Add("active", active?.ToString().ToLowerInvariant());
             UrlParameters.Add("actual_hours", actualHours.ToString().ToLowerInvariant());

--- a/TogglApi.Client/General/Models/Request/WorkspaceTaskRequestConfig.cs
+++ b/TogglApi.Client/General/Models/Request/WorkspaceTaskRequestConfig.cs
@@ -7,7 +7,7 @@ namespace TogglApi.Client.General.Models.Request
     public class WorkspaceTaskRequestConfig : BaseRequestConfig
     {
         public WorkspaceTaskRequestConfig(long workspaceId, bool? active=null) : base(
-            $"https://www.toggl.com/api/v8/workspaces/{workspaceId}/tasks")
+            $"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/tasks")
         {
             UrlParameters.Add("active", active?.ToString().ToLowerInvariant());
         }

--- a/TogglApi.Client/General/TogglWorkspaceClient.cs
+++ b/TogglApi.Client/General/TogglWorkspaceClient.cs
@@ -15,13 +15,13 @@ namespace TogglApi.Client.General
 
         public async Task<List<Workspace>> GetWorkspaces(string apiToken)
         {
-            return await GetGenericTogglApi<List<Workspace>>(url: "https://www.toggl.com/api/v8/workspaces",
+            return await GetGenericTogglApi<List<Workspace>>(url: "https://api.track.toggl.com/api/v8/workspaces",
                 apiToken: apiToken).ConfigureAwait(false);
         }
 
         public async Task<Workspace> GetWorkspace(string apiToken, long workspaceId)
         {
-            return (await GetGenericTogglApi<WorkspaceContainer>(url: $"https://www.toggl.com/api/v8/workspaces/{workspaceId}",
+            return (await GetGenericTogglApi<WorkspaceContainer>(url: $"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}",
                 apiToken: apiToken).ConfigureAwait(false)).Workspace;
         }
 
@@ -38,19 +38,19 @@ namespace TogglApi.Client.General
         public async Task<List<User>> GetUsers(string apiToken, long workspaceId)
         {
             return await GetGenericTogglApi<List<User>>(
-                url: $"https://www.toggl.com/api/v8/workspaces/{workspaceId}/users", apiToken: apiToken).ConfigureAwait(false);
+                url: $"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/users", apiToken: apiToken).ConfigureAwait(false);
         }
 
         public async Task<List<Models.Response.Client>> GetClients(string apiToken, long workspaceId)
         {
             return await GetGenericTogglApi<List<Models.Response.Client>>(
-                url: $"https://www.toggl.com/api/v8/workspaces/{workspaceId}/users", apiToken: apiToken).ConfigureAwait(false);
+                url: $"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/users", apiToken: apiToken).ConfigureAwait(false);
         }
 
         public async Task<List<Tag>> GetTags(string apiToken, long workspaceId)
         {
             return await GetGenericTogglApi<List<Tag>>(
-                url: $"https://www.toggl.com/api/v8/workspaces/{workspaceId}/tags", apiToken: apiToken).ConfigureAwait(false);
+                url: $"https://api.track.toggl.com/api/v8/workspaces/{workspaceId}/tags", apiToken: apiToken).ConfigureAwait(false);
         }
 
         public async Task<List<Models.Response.Task>> GetTasks(string apiToken, WorkspaceTaskRequestConfig config)

--- a/TogglApi.Client/Reports/Models/ReportConfig.cs
+++ b/TogglApi.Client/Reports/Models/ReportConfig.cs
@@ -13,7 +13,7 @@ namespace TogglApi.Client.Reports.Models
             IList<int> taskIds = null, IList<int> timeEntryIds = null, string description = null,
             bool withoutDescription = false, string orderField = null, bool orderDescending = false,
             bool distinctRates = false, bool rounding = false, DisplayHours? displayHours = null) :
-            base($"https://toggl.com/reports/api/v2/{reportType.UrlRepresentation()}")
+            base($"https://api.track.toggl.com/reports/api/v2/{reportType.UrlRepresentation()}")
         {
             UrlParameters.Add("user_agent", userAgent);
             UrlParameters.Add("workspace_id", workspaceId);


### PR DESCRIPTION
The existing www.toggl.com/api is getting turned off in June 2021 (see https://github.com/toggl/toggl_api_docs#toggl-api-documentation). This PR updates the client to use the new endpoint.

I've confirmed that I can build the solution and the tests all continue to pass.